### PR TITLE
add summary parameter

### DIFF
--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -55,4 +55,4 @@ send_as_file/%:
 	cat sample.txt | curl -d @- -H "Content-Type: text/plain" $(shell tfstate-lookup --state .terraform/terraform.tfstate aws_lambda_function_url.nowpaste.function_url)?as_file=true\&channel=$*
 
 send_json/%:
-	cat sample.json | curl -d @- -H "Content-Type: text/plain" $(shell tfstate-lookup --state .terraform/terraform.tfstate aws_lambda_function_url.nowpaste.function_url)?code_block_text=true\&channel=$*
+	cat sample.json | curl -d @- -H "Content-Type: application/json" $(shell tfstate-lookup --state .terraform/terraform.tfstate aws_lambda_function_url.nowpaste.function_url)?code_block_text=true\&channel=$*\&summary=test

--- a/nowpaste.go
+++ b/nowpaste.go
@@ -115,11 +115,6 @@ func (nwp *NowPaste) newContent(req *http.Request) *Content {
 func (nwp *NowPaste) postDefault(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 	content := nwp.newContent(req)
-	channel := req.URL.Query().Get("channel")
-	if channel == "" {
-		http.Error(w, "query param `channel` is required", http.StatusBadRequest)
-		return
-	}
 	username := req.URL.Query().Get("username")
 	if username == "" {
 		username = "nowpaste"
@@ -139,7 +134,7 @@ func (nwp *NowPaste) postDefault(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	content.Merge(&Content{
-		Channel:       channel,
+		Channel:       req.URL.Query().Get("channel"),
 		Username:      username,
 		EscapeText:    escapeText,
 		CodeBlockText: codeBlockText,
@@ -210,6 +205,10 @@ func (nwp *NowPaste) postDefault(w http.ResponseWriter, req *http.Request) {
 		content.Merge(&Content{
 			Text: string(bs),
 		})
+	}
+	if content.Channel == "" {
+		http.Error(w, "query param `channel` is required", http.StatusBadRequest)
+		return
 	}
 	if err := nwp.postContent(req.Context(), content); err != nil {
 		var rle *slack.RateLimitedError

--- a/nowpaste.go
+++ b/nowpaste.go
@@ -643,6 +643,9 @@ func (nwp *NowPaste) postMessage(ctx context.Context, content *Content) error {
 		opts = append(opts, slack.MsgOptionAttachments(content.Attachments...))
 	}
 	if content.Text != "" {
+		if content.Summary != "" {
+			content.Text = content.Summary + "\n\n" + content.Text
+		}
 		if len(content.Text) > textMaxLength {
 			content.Text = content.Text[:textMaxLength-100]
 			content.Text += "\n...(truncated)"

--- a/testdata/post_root_retry_once/many_lines.golden
+++ b/testdata/post_root_retry_once/many_lines.golden
@@ -2,11 +2,11 @@
 POST /api/files.getUploadURLExternal HTTP/1.1
 Host: slack.com
 User-Agent: Go-http-client/1.1
-Content-Length: 46
+Content-Length: 49
 Content-Type: application/x-www-form-urlencoded
 Accept-Encoding: gzip
 
-filename=nowpaste&length=126&token=dummy_token
+filename=message.txt&length=126&token=dummy_token
 --- response status ---
 429 Too Many Requests
 =====================
@@ -14,11 +14,11 @@ filename=nowpaste&length=126&token=dummy_token
 POST /api/files.getUploadURLExternal HTTP/1.1
 Host: slack.com
 User-Agent: Go-http-client/1.1
-Content-Length: 46
+Content-Length: 49
 Content-Type: application/x-www-form-urlencoded
 Accept-Encoding: gzip
 
-filename=nowpaste&length=126&token=dummy_token
+filename=message.txt&length=126&token=dummy_token
 --- response status ---
 200 OK
 =====================
@@ -31,9 +31,9 @@ Authorization: Bearer dummy_token
 Content-Type: multipart/form-data; boundary=000000000000000000000000000000000000000000000000000000000000
 Accept-Encoding: gzip
 
-1b2
+1b5
 --000000000000000000000000000000000000000000000000000000000000
-Content-Disposition: form-data; name="file"; filename="nowpaste"
+Content-Disposition: form-data; name="file"; filename="message.txt"
 Content-Type: application/octet-stream
 
 this is test message

--- a/testdata/post_root_retry_once/short.golden
+++ b/testdata/post_root_retry_once/short.golden
@@ -2,11 +2,11 @@
 POST /api/chat.postMessage HTTP/1.1
 Host: slack.com
 User-Agent: Go-http-client/1.1
-Content-Length: 59
+Content-Length: 77
 Content-Type: application/x-www-form-urlencoded
 Accept-Encoding: gzip
 
-channel=%23test&text=this+is+test+message&token=dummy_token
+channel=%23test&text=this+is+test+message&token=dummy_token&username=nowpaste
 --- response status ---
 429 Too Many Requests
 =====================
@@ -14,11 +14,11 @@ channel=%23test&text=this+is+test+message&token=dummy_token
 POST /api/chat.postMessage HTTP/1.1
 Host: slack.com
 User-Agent: Go-http-client/1.1
-Content-Length: 59
+Content-Length: 77
 Content-Type: application/x-www-form-urlencoded
 Accept-Encoding: gzip
 
-channel=%23test&text=this+is+test+message&token=dummy_token
+channel=%23test&text=this+is+test+message&token=dummy_token&username=nowpaste
 --- response status ---
 200 OK
 =====================

--- a/testdata/post_root_success/many_lines.golden
+++ b/testdata/post_root_success/many_lines.golden
@@ -2,11 +2,11 @@
 POST /api/files.getUploadURLExternal HTTP/1.1
 Host: slack.com
 User-Agent: Go-http-client/1.1
-Content-Length: 46
+Content-Length: 49
 Content-Type: application/x-www-form-urlencoded
 Accept-Encoding: gzip
 
-filename=nowpaste&length=126&token=dummy_token
+filename=message.txt&length=126&token=dummy_token
 --- response status ---
 200 OK
 =====================
@@ -19,9 +19,9 @@ Authorization: Bearer dummy_token
 Content-Type: multipart/form-data; boundary=000000000000000000000000000000000000000000000000000000000000
 Accept-Encoding: gzip
 
-1b2
+1b5
 --000000000000000000000000000000000000000000000000000000000000
-Content-Disposition: form-data; name="file"; filename="nowpaste"
+Content-Disposition: form-data; name="file"; filename="message.txt"
 Content-Type: application/octet-stream
 
 this is test message

--- a/testdata/post_root_success/short.golden
+++ b/testdata/post_root_success/short.golden
@@ -2,11 +2,11 @@
 POST /api/chat.postMessage HTTP/1.1
 Host: slack.com
 User-Agent: Go-http-client/1.1
-Content-Length: 59
+Content-Length: 77
 Content-Type: application/x-www-form-urlencoded
 Accept-Encoding: gzip
 
-channel=%23test&text=this+is+test+message&token=dummy_token
+channel=%23test&text=this+is+test+message&token=dummy_token&username=nowpaste
 --- response status ---
 200 OK
 =====================


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the `nowpaste` service. The main changes include adding support for a summary field in the `Content` struct, improving how content is processed and posted, and updating the `Makefile` to handle JSON content correctly.

Enhancements and bug fixes:

* **Support for Summary Field**:
  - Added a `Summary` field to the `Content` struct to provide a brief description of the content.
  - Updated the `Merge` method to handle the new `Summary` field.
  - Modified the `postFile` and `postMessage` methods to include the summary when posting content. [[1]](diffhunk://#diff-d9e44f8144eb44650f5596cee3a6bca86b36fcbc21115faac8008baa8b6ed28eR557) [[2]](diffhunk://#diff-d9e44f8144eb44650f5596cee3a6bca86b36fcbc21115faac8008baa8b6ed28eR673-R675)

* **Content Processing Improvements**:
  - Refactored the `postDefault` method to handle query parameters more efficiently, including the new `summary` parameter. [[1]](diffhunk://#diff-d9e44f8144eb44650f5596cee3a6bca86b36fcbc21115faac8008baa8b6ed28eR118-R149) [[2]](diffhunk://#diff-d9e44f8144eb44650f5596cee3a6bca86b36fcbc21115faac8008baa8b6ed28eR180) [[3]](diffhunk://#diff-d9e44f8144eb44650f5596cee3a6bca86b36fcbc21115faac8008baa8b6ed28eL171-L207)
  - Introduced the `DetermineExtension` function to dynamically determine the file extension based on content type.

* **Makefile Update**:
  - Updated the `send_json/%:` target in the `Makefile` to set the correct `Content-Type` header and include the `summary` parameter.

These changes enhance the functionality and flexibility of the `nowpaste` service, making it easier to manage and post content with summaries.